### PR TITLE
HB-4935: Simplify use of unknown errors in adapters

### DIFF
--- a/Source/MintegralAdapterBannerAd.swift
+++ b/Source/MintegralAdapterBannerAd.swift
@@ -64,7 +64,7 @@ extension MintegralAdapterBannerAd: MTGBannerAdViewDelegate {
     }
 
     func adViewLoadFailedWithError(_ partnerError: Error?, adView: MTGBannerAdView?) {
-        let error = error(.loadFailureUnknown, error: partnerError)
+        let error = partnerError ?? self.error(.loadFailureUnknown)
         log(.loadFailed(error))
         loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
         loadCompletion = nil

--- a/Source/MintegralAdapterInterstitialAd.swift
+++ b/Source/MintegralAdapterInterstitialAd.swift
@@ -61,9 +61,8 @@ extension MintegralAdapterInterstitialAd: MTGNewInterstitialAdDelegate {
     }
 
     func newInterstitialAdLoadFail(_ partnerError: Error, adManager: MTGNewInterstitialAdManager) {
-        let error = error(.loadFailureUnknown, error: partnerError)
-        log(.loadFailed(error))
-        loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
+        log(.loadFailed(partnerError))
+        loadCompletion?(.failure(partnerError)) ?? log(.loadResultIgnored)
         loadCompletion = nil
     }
 
@@ -74,9 +73,8 @@ extension MintegralAdapterInterstitialAd: MTGNewInterstitialAdDelegate {
     }
 
     func newInterstitialAdShowFail(_ partnerError: Error, adManager: MTGNewInterstitialAdManager) {
-        let error = error(.showFailureUnknown, error: partnerError)
-        log(.showFailed(error))
-        showCompletion?(.failure(error)) ?? log(.showResultIgnored)
+        log(.showFailed(partnerError))
+        showCompletion?(.failure(partnerError)) ?? log(.showResultIgnored)
         showCompletion = nil
     }
 

--- a/Source/MintegralAdapterInterstitialBidAd.swift
+++ b/Source/MintegralAdapterInterstitialBidAd.swift
@@ -68,9 +68,8 @@ extension MintegralAdapterInterstitialBidAd: MTGNewInterstitialBidAdDelegate {
     }
 
     func newInterstitialBidAdLoadFail(_ partnerError: Error, adManager: MTGNewInterstitialBidAdManager) {
-        let error = error(.loadFailureUnknown, error: partnerError)
-        log(.loadFailed(error))
-        loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
+        log(.loadFailed(partnerError))
+        loadCompletion?(.failure(partnerError)) ?? log(.loadResultIgnored)
         loadCompletion = nil
     }
 
@@ -81,9 +80,8 @@ extension MintegralAdapterInterstitialBidAd: MTGNewInterstitialBidAdDelegate {
     }
 
     func newInterstitialBidAdShowFail(_ partnerError: Error, adManager: MTGNewInterstitialBidAdManager) {
-        let error = error(.showFailureUnknown, error: partnerError)
-        log(.showFailed(error))
-        showCompletion?(.failure(error)) ?? log(.showResultIgnored)
+        log(.showFailed(partnerError))
+        showCompletion?(.failure(partnerError)) ?? log(.showResultIgnored)
         showCompletion = nil
     }
 

--- a/Source/MintegralAdapterRewardedAd.swift
+++ b/Source/MintegralAdapterRewardedAd.swift
@@ -77,9 +77,8 @@ extension MintegralAdapterRewardedAd: MTGRewardAdLoadDelegate {
     }
 
     func onVideoAdLoadFailed(_ placementId: String?, unitId: String?, error partnerError: Error) {
-        let error = error(.loadFailureUnknown, error: partnerError)
-        log(.loadFailed(error))
-        loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
+        log(.loadFailed(partnerError))
+        loadCompletion?(.failure(partnerError)) ?? log(.loadResultIgnored)
         loadCompletion = nil
     }
 }
@@ -93,9 +92,8 @@ extension MintegralAdapterRewardedAd: MTGRewardAdShowDelegate {
     }
 
     func onVideoAdShowFailed(_ placementId: String?, unitId: String?, withError partnerError: Error) {
-        let error = error(.showFailureUnknown, error: partnerError)
-        log(.showFailed(error))
-        showCompletion?(.failure(error)) ?? log(.showResultIgnored)
+        log(.showFailed(partnerError))
+        showCompletion?(.failure(partnerError)) ?? log(.showResultIgnored)
         showCompletion = nil
     }
 


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-4935

Partner errors can now be directly used with `PartnerAdLogEvent` and the completion handlers, which will get auto-wrapped within a `HeliumError` with the appropriate `unknown` code, per the work done in https://github.com/ChartBoost/ios-helium-sdk/pull/882.  Also, partners that supply a code can create an error using the `PartnerAd.partnerError(_code:)` method instead.
