### PR TITLE
HB-5057: import ChartboostMediationSDK instead of HeliumSdk

### DIFF
--- a/Source/MintegralAdapter.swift
+++ b/Source/MintegralAdapter.swift
@@ -8,11 +8,11 @@
 //  ChartboostHeliumAdapterMintegral
 //
 
+import ChartboostMediationSDK
 import Foundation
-import UIKit
-import HeliumSdk
 import MTGSDK
 import MTGSDKBidding
+import UIKit
 
 /// Helium Mintegral adapter.
 final class MintegralAdapter: PartnerAdapter {

--- a/Source/MintegralAdapterAd.swift
+++ b/Source/MintegralAdapterAd.swift
@@ -8,8 +8,8 @@
 //  ChartboostHeliumAdapterMintegral
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
 import MTGSDK
 import UIKit
 

--- a/Source/MintegralAdapterBannerAd.swift
+++ b/Source/MintegralAdapterBannerAd.swift
@@ -8,8 +8,8 @@
 //  ChartboostHeliumAdapterMintegral
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
 import MTGSDK
 import MTGSDKBanner
 

--- a/Source/MintegralAdapterInterstitialAd.swift
+++ b/Source/MintegralAdapterInterstitialAd.swift
@@ -8,8 +8,8 @@
 //  ChartboostHeliumAdapterMintegral
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
 import MTGSDK
 import MTGSDKNewInterstitial
 

--- a/Source/MintegralAdapterInterstitialBidAd.swift
+++ b/Source/MintegralAdapterInterstitialBidAd.swift
@@ -8,8 +8,8 @@
 //  ChartboostHeliumAdapterMintegral
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
 import MTGSDK
 import MTGSDKNewInterstitial
 

--- a/Source/MintegralAdapterRewardedAd.swift
+++ b/Source/MintegralAdapterRewardedAd.swift
@@ -8,8 +8,8 @@
 //  ChartboostHeliumAdapterMintegral
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
 import MTGSDK
 import MTGSDKReward
 


### PR DESCRIPTION
This is a companion PR of https://github.com/ChartBoost/ios-helium-sdk/pull/942.

Discussed with Dani and decided to merge the tedious adapter PR's without code review to speed up the whole rebranding process.