### PR TITLE
Remove PartnerAdapterFormat.adaptive_banner

### DIFF
--- a/Source/MintegralAdapter.swift
+++ b/Source/MintegralAdapter.swift
@@ -126,7 +126,6 @@ final class MintegralAdapter: PartnerAdapter {
         // ChartboostMediationSDK 4.x does not support loading more than 2 banners with the same placement, and the partner may or may not support it.
         guard !storage.ads.contains(where: { $0.request.partnerPlacement == request.partnerPlacement })
             || request.format == PartnerAdFormats.banner
-            || request.format == PartnerAdFormats.adaptiveBanner
         else {
             log("Failed to load ad for already loading placement \(request.partnerPlacement)")
             throw error(.loadFailureLoadInProgress)
@@ -141,7 +140,7 @@ final class MintegralAdapter: PartnerAdapter {
             }
         case PartnerAdFormats.rewarded:
             return try MintegralAdapterRewardedAd(adapter: self, request: request, delegate: delegate)
-        case PartnerAdFormats.banner, PartnerAdFormats.adaptiveBanner:
+        case PartnerAdFormats.banner:
             return try MintegralAdapterBannerAd(adapter: self, request: request, delegate: delegate)
         default:
             throw error(.loadFailureUnsupportedAdFormat)

--- a/Source/MintegralAdapterBannerAd.swift
+++ b/Source/MintegralAdapterBannerAd.swift
@@ -26,7 +26,7 @@ final class MintegralAdapterBannerAd: MintegralAdapterAd, PartnerAd {
         log(.loadStarted)
 
         // Fail if we cannot fit a fixed size banner in the requested size.
-        guard let size = fixedBannerSize(for: request.size ?? IABStandardAdSize) else {
+        guard let size = fixedBannerSize(for: request.bannerSize) else {
             let error = error(.loadFailureInvalidBannerSize)
             log(.loadFailed(error))
             return completion(.failure(error))
@@ -111,13 +111,16 @@ extension MintegralAdapterBannerAd: MTGBannerAdViewDelegate {
 
 // MARK: - Helpers
 extension MintegralAdapterBannerAd {
-    private func fixedBannerSize(for requestedSize: CGSize) -> CGSize? {
+    private func fixedBannerSize(for requestedSize: BannerSize?) -> CGSize? {
+        guard let requestedSize else {
+            return IABStandardAdSize
+        }
         let sizes = [IABLeaderboardAdSize, IABMediumAdSize, IABStandardAdSize]
         // Find the largest size that can fit in the requested size.
         for size in sizes {
             // If height is 0, the pub has requested an ad of any height, so only the width matters.
-            if requestedSize.width >= size.width &&
-                (size.height == 0 || requestedSize.height >= size.height) {
+            if requestedSize.size.width >= size.width &&
+                (size.height == 0 || requestedSize.size.height >= size.height) {
                 return size
             }
         }


### PR DESCRIPTION
Updated implementation for removal of PartnerAdapterFormats.adaptive_banner and additiong of a BannerSize property in PartnerAdLoadRequest